### PR TITLE
Feat attribute xml

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -91,7 +91,11 @@ class ArrayToXml
 
         foreach ($value as $key => $data) {
             if (! $sequential) {
-                $this->addNode($element, $key, $data);
+                if ($key ==='_attributes') {
+                    $this->addAttribtues($element, $data);
+                } else {
+                    $this->addNode($element, $key, $data);
+                }
             } elseif (is_array($data)) {
                 $this->addCollectionNode($element, $data);
             } else {
@@ -178,5 +182,18 @@ class ArrayToXml
         }
 
         return array_unique(array_map("is_int", array_keys($value))) === array(true);
+    }
+    
+    /**
+     * Add attributes
+     *
+     * @param \DOMElement     $element
+     * @param string[] $data
+     */
+    protected function addAttribtues($element, $data)
+    {
+        foreach ($data as $attrKey => $attrVal) {
+            $element->setAttribute($attrKey, $attrVal);
+        }
     }
 }

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -93,6 +93,8 @@ class ArrayToXml
             if (! $sequential) {
                 if ($key ==='_attributes') {
                     $this->addAttribtues($element, $data);
+                } elseif ($key === '_value' && is_string($data)) {
+                    $element->nodeValue = $data;
                 } else {
                     $this->addNode($element, $key, $data);
                 }

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -194,4 +194,18 @@ class ArrayToXmlTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedXml, $result);
     }
+    /**
+     * @test
+     */
+    public function it_support_now_attribtues_to_xml()
+    {
+
+        $expectedXml = '<?xml version="1.0"?>
+<root><Good_guy nameType="1"><name>Luke Skywalker</name><weapon>Lightsaber</weapon></Good_guy><Bad_guy><name>Sauron</name><weapon>Evil Eye</weapon></Bad_guy></root>'.PHP_EOL;
+        $withAttributes = $this->testArray;
+        $withAttributes['Good guy']['_attributes']= ['nameType' => 1];
+        $result = ArrayToXml::convert($withAttributes);
+
+        $this->assertEquals($expectedXml, $result);
+    }
 }

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -208,4 +208,19 @@ class ArrayToXmlTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedXml, $result);
     }
+
+    /**
+     * @test
+     */
+    public function it_support_now_attribtues_to_xml_with_value()
+    {
+
+        $expectedXml = '<?xml version="1.0"?>
+<root><Good_guy nameType="1"><name>Luke Skywalker</name><weapon>Lightsaber</weapon></Good_guy><Bad_guy><name>Sauron</name><weapon>Evil Eye</weapon></Bad_guy></root>'.PHP_EOL;
+        $withAttributes = $this->testArray;
+        $withAttributes['Good guy']['_attributes']= ['nameType' => 1];
+        $result = ArrayToXml::convert($withAttributes);
+
+        $this->assertEquals($expectedXml, $result);
+    }    
 }


### PR DESCRIPTION
New feature that allow to have `<tagName attr1="value" />`

Usage
```
$array = [
    'Good guy' => [
        '_attributes' => ['attr1' => 'value']
        'name' => 'Luke Skywalker',
        'weapon' => 'Lightsaber'
    ],
    'Bad guy' => [
        'name' => 'Sauron',
        'weapon' => 'Evil Eye'
    ]
];

$result = ArrayToXml::convert($array);
```
Will give
```xml
<?xml version="1.0"?>
<root>
    <Good_guy attr1="value">
        <name>Luke Skywalker</name>
        <weapon>Lightsaber</weapon>
    </Good_guy>
    <Bad_guy>
        <name>Sauron</name>
        <weapon>Evil Eye</weapon>
    </Bad_guy>
</root>
```


You can also want to have something like that
```<weapon price="55" stock="2">LightSaber</weapon>```

for that we''ll have XML array like that

phpunit has been addded

```
$array = [
    'Good guy' => [
        '_attributes' => ['attr1' => 'value']
        'name' => 'Luke Skywalker',
        'weapon' => [
                '_attributes' => [
                     'price'=> 55, 
                     'stock'=> 2
                ],
                '_value' => 'Lightsaber'
    ],
    'Bad guy' => [
        'name' => 'Sauron',
        'weapon' => 'Evil Eye'
    ]
];

$result = ArrayToXml::convert($array);
```