### PR TITLE
Fixed an error when there is a special character to the value set in _value

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -104,7 +104,7 @@ class ArrayToXml
                 if ($key === '_attributes') {
                     $this->addAttributes($element, $data);
                 } elseif ($key === '_value' && is_string($data)) {
-                    $element->nodeValue = $data;
+                    $element->nodeValue = htmlspecialchars($data);
                 } else {
                     $this->addNode($element, $key, $data);
                 }

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -208,4 +208,34 @@ class ArrayToXmlTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedXml, $result);
     }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_values_set_with_attributes_with_special_characters()
+    {
+        $expectedXml = '<?xml version="1.0"?>
+<root><movie><title category="SF">STAR WARS</title></movie><movie><title category="Children">tom &amp; jerry</title></movie></root>'.PHP_EOL;
+
+        $array = [
+            'movie' => [
+                [
+                    'title' => [
+                        '_attributes' => ['category' => 'SF'],
+                        '_value' => 'STAR WARS'
+                    ]
+                ],
+                [
+                    'title' => [
+                        '_attributes' => ['category' => 'Children'],
+                        '_value' => 'tom & jerry'
+                    ]
+                ]
+            ]
+        ];
+
+        $result = ArrayToXml::convert($array);
+
+        $this->assertEquals($expectedXml, $result);
+    }
 }


### PR DESCRIPTION
I tried to create a XML in this case.

```php
$array = [
    'movie' => [
        [
            'title' => [
                '_attributes' => ['category' => 'SF'],
                '_value' => 'STAR WARS'
            ]
        ],
        [
            'title' => [
                '_attributes' => ['category' => 'Children'],
                '_value' => 'tom & jerry'
            ]
        ]
    ]
];

$result = ArrayToXml::convert($array);
```

This results expected.

```xml
<?xml version="1.0"?>
<root>
    <movie>
        <title category="SF">STAR WARS</title>
    </movie>
    <movie>
        <title category="Children">tom &amp; jerry</title>
    </movie>
</root>
```

But, test fails.

```
Spatie\ArrayToXml\ArrayToXml::convertElement(): unterminated entity reference
```

It was fixed because it is very convenient library.