### PR TITLE
Move phpunit-snapshot-assertions to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         }
     ],
     "require": {
-        "php" : "^5.6|^7.0",
-        "spatie/phpunit-snapshot-assertions": "^0.4.1"
+        "php" : "^5.6|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^5.7",
-        "mockery/mockery": "0.9.*"
+        "mockery/mockery": "0.9.*",
+        "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I don't see any reason why it's needed under `"require"` section