### PR TITLE
Fixed attribute only collections being overridden

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -148,7 +148,7 @@ class ArrayToXml
      */
     protected function addCollectionNode(DOMElement $element, $value)
     {
-        if ($element->childNodes->length == 0) {
+        if ($element->childNodes->length == 0 && $element->attributes->length == 0) {
             $this->convertElement($element, $value);
 
             return;

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -179,6 +179,27 @@ class ArrayToXmlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_handle_attributes_as_collection()
+    {
+        $this->assertMatchesXmlSnapshot(ArrayToXml::convert([
+            'user' => [
+                [
+                    '_attributes' => [
+                        'name' => 'een',
+                        'age' => 10,
+                    ]
+                ],
+                [
+                    '_attributes' => [
+                        'name' => 'twee',
+                        'age' => 12,
+                    ]
+                ],
+            ],
+        ]));
+    }
+
+    /** @test */
     public function and_attributes_also_can_be_set_in_simplexmlelement_style()
     {
         $withAttributes = $this->testArray;

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_handle_attributes_as_collection__1.xml
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_handle_attributes_as_collection__1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<root>
+  <user name="een" age="10"/>
+  <user name="twee" age="12"/>
+</root>


### PR DESCRIPTION
Change in behaviour:
```xml

// previous
+<root>
+  <user name="twee" age="12"/>
+</root>

// fixed
+<root>
+  <user name="een" age="10"/>
+  <user name="twee" age="12"/>
+</root>
```

Edit; I only now see that there was already someone running into the same problem. So I guess this fixes https://github.com/spatie/array-to-xml/issues/35