### PR TITLE
Allow to wrap the data in a CDATA section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,41 @@ This code will result in:
 </root>
 ```
 
+It is also possible to wrap the value of a node into a CDATA section. This allows you to use reserved characters.
+
+```php
+$array = [
+    'Good guy' => [
+        'name' => [
+            '_cdata' => '<h1>Luke Skywalker</h1>'
+        ],
+        'weapon' => 'Lightsaber'
+    ],
+    'Bad guy' => [
+        'name' => '<h1>Sauron</h1>',
+        'weapon' => 'Evil Eye'
+    ]
+];
+
+$result = ArrayToXml::convert($array);
+```
+
+This code will result in:
+
+```xml
+<?xml version="1.0"?>
+<root>
+    <Good_guy>
+        <name><![CDATA[<h1>Luke Skywalker</h1>]]></name>
+        <weapon>Lightsaber</weapon>
+    </Good_guy>
+    <Bad_guy>
+        <name>&lt;h1&gt;Sauron&lt;/h1&gt;</name>
+        <weapon>Evil Eye</weapon>
+    </Bad_guy>
+</root>
+```
+
 If your input contains something that cannot be parsed a `DOMException` will be thrown.
 
 To add attributes to the root element provide an array with an `_attributes` key as the second argument. 

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -11,7 +11,7 @@ class ArrayToXml
     /**
      * The root DOM Document.
      *
-     * @var \DOMDocument
+     * @var DOMDocument
      */
     protected $document;
 
@@ -90,7 +90,7 @@ class ArrayToXml
     /**
      * Parse individual element.
      *
-     * @param \DOMElement $element
+     * @param DOMElement $element
      * @param string|string[] $value
      */
     private function convertElement(DOMElement $element, $value)
@@ -109,6 +109,8 @@ class ArrayToXml
                     $this->addAttributes($element, $data);
                 } elseif ((($key === '_value') || ($key === '@value')) && is_string($data)) {
                     $element->nodeValue = htmlspecialchars($data);
+                } elseif ((($key === '_cdata') || ($key === '@cdata')) && is_string($data)) {
+                    $element->appendChild($this->document->createCDATASection($data));
                 } else {
                     $this->addNode($element, $key, $data);
                 }
@@ -123,7 +125,7 @@ class ArrayToXml
     /**
      * Add node.
      *
-     * @param \DOMElement $element
+     * @param DOMElement $element
      * @param string $key
      * @param string|string[] $value
      */
@@ -141,7 +143,7 @@ class ArrayToXml
     /**
      * Add collection node.
      *
-     * @param \DOMElement $element
+     * @param DOMElement $element
      * @param string|string[] $value
      *
      * @internal param string $key
@@ -162,7 +164,7 @@ class ArrayToXml
     /**
      * Add sequential node.
      *
-     * @param \DOMElement $element
+     * @param DOMElement $element
      * @param string|string[] $value
      *
      * @internal param string $key
@@ -203,7 +205,7 @@ class ArrayToXml
     /**
      * Add attributes.
      *
-     * @param \DOMElement $element
+     * @param DOMElement $element
      * @param string[] $data
      */
     protected function addAttributes($element, $data)

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -250,4 +250,46 @@ class ArrayToXmlTest extends TestCase
             ],
         ]));
     }
+
+    /** @test */
+    public function it_can_handle_values_set_as_cdata()
+    {
+        $this->assertMatchesSnapshot(ArrayToXml::convert([
+            'movie' => [
+                [
+                    'title' => [
+                        '_attributes' => ['category' => 'SF'],
+                        '_cdata' => '<p>STAR WARS</p>',
+                    ],
+                ],
+                [
+                    'title' => [
+                        '_attributes' => ['category' => 'Children'],
+                        '_cdata' => '<p>tom & jerry</p>',
+                    ],
+                ],
+            ],
+        ]));
+    }
+
+    /** @test */
+    public function and_cdata_values_can_also_be_set_in_simplexmlelement_style()
+    {
+        $this->assertMatchesSnapshot(ArrayToXml::convert([
+            'movie' => [
+                [
+                    'title' => [
+                        '@attributes' => ['category' => 'SF'],
+                        '@cdata' => '<p>STAR WARS</p>',
+                    ],
+                ],
+                [
+                    'title' => [
+                        '@attributes' => ['category' => 'Children'],
+                        '@cdata' => '<p>tom & jerry</p>',
+                    ],
+                ],
+            ],
+        ]));
+    }
 }

--- a/tests/__snapshots__/ArrayToXmlTest__and_cdata_values_can_also_be_set_in_simplexmlelement_style__1.php
+++ b/tests/__snapshots__/ArrayToXmlTest__and_cdata_values_can_also_be_set_in_simplexmlelement_style__1.php
@@ -1,0 +1,3 @@
+<?php return '<?xml version="1.0"?>
+<root><movie><title category="SF"><![CDATA[<p>STAR WARS</p>]]></title></movie><movie><title category="Children"><![CDATA[<p>tom & jerry</p>]]></title></movie></root>
+';

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_handle_values_set_as_cdata__1.php
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_handle_values_set_as_cdata__1.php
@@ -1,0 +1,3 @@
+<?php return '<?xml version="1.0"?>
+<root><movie><title category="SF"><![CDATA[<p>STAR WARS</p>]]></title></movie><movie><title category="Children"><![CDATA[<p>tom & jerry</p>]]></title></movie></root>
+';


### PR DESCRIPTION
This PR adds a new `_cdata` and `@cdata` key to convert the given data to a CDATA section which allows the use of reserved characters. 

The following example,

```php
ArrayToXml::convert([
    'movie' => [
        [
            'title' => [
                '@attributes' => ['category' => 'SF'],
                '@value' => '<p>STAR WARS</p>',
            ],
        ],
        [
            'title' => [
                '@attributes' => ['category' => 'Children'],
                '@cdata' => '<p>tom & jerry</p>',
            ],
        ],
    ],
]);
```

transforms to:

```xml
<?xml version="1.0"?>
<root>
  <movie>
    <title category="SF">&lt;p&gt;STAR WARS&lt;/p&gt;</title>
  </movie>
  <movie>
    <title category="Children"><![CDATA[<p>tom & jerry</p>]]></title>
  </movie>
</root>
```

I had to use `assertMatchesSnapshot` instead of `assertMatchesXmlSnapshot` in the tests since `assertMatchesXmlSnapshot` doesn't work as intended with the CDATA section. 