### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit" : "^6.3",
-        "mockery/mockery": "0.9.*",
+        "mockery/mockery": "^1.0",
         "spatie/phpunit-snapshot-assertions": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).