### PR TITLE
#108 Self-closing element on null value

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -99,6 +99,10 @@ class ArrayToXml
     private function convertElement(DOMElement $element, $value)
     {
         $sequential = $this->isArrayAllKeySequential($value);
+        
+        if ($value === null) {
+            return;
+        }
 
         if (! is_array($value)) {
             $value = htmlspecialchars($value);


### PR DESCRIPTION
Allow self-closing element on null values

```
$array = [
  'Id' => 123,
  'Firstname' => '',
  'Lastname' => null
];

$arrayToXml = new ArrayToXml($array, 'Customer');
$arrayToXml->setDomProperties(['formatOutput' => true]);
return $arrayToXml->toXml();
```

Will give:
```
<?xml version="1.0"?>
<Customer>
  <Id>123</Id>
  <Firstname></Firstname>
  <Lastname/>
</Customer>
```