### PR TITLE
Fix for zero values interpreted as empty

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -168,7 +168,7 @@ class ArrayToXml
 
     protected function addSequentialNode(DOMElement $element, $value)
     {
-        if (empty($element->nodeValue)) {
+        if (empty($element->nodeValue) && ! is_numeric($element->nodeValue)) {
             $element->nodeValue = htmlspecialchars($value);
 
             return;

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -107,6 +107,14 @@ class ArrayToXmlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_handle_zero_values_in_beginning_of_basic_collection()
+    {
+        $this->assertMatchesXmlSnapshot(ArrayToXml::convert([
+            'user' => ['0', '1', '0'],
+        ]));
+    }
+
+    /** @test */
     public function it_accepts_an_xml_encoding_type()
     {
         $this->assertMatchesXmlSnapshot(ArrayToXml::convert([], '', false, 'UTF-8'));

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_handle_zero_values_in_beginning_of_basic_collection__1.xml
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_handle_zero_values_in_beginning_of_basic_collection__1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<root>
+  <user>0</user>
+  <user>1</user>
+  <user>0</user>
+</root>


### PR DESCRIPTION
As reported in https://github.com/spatie/array-to-xml/issues/111, it appears that:

`ArrayToXml::convert(['a' => ['0', '1']])`

will result in:
`<root><a>1</a></root>`

while:
`ArrayToXml::convert(['a' => ['1', '0']])`

results in:
`<root><a>1</a><a>0</a></root>`


Reason for that is that `empty` evaluates as true for 0 as string, 0 as float and 0 as integer:
https://github.com/spatie/array-to-xml/blob/68a181261df9ba16688abb87d8658638157b8f90/src/ArrayToXml.php#L171


Requesting a review for my proposed solution as it may be a breaking change.
