### PR TITLE
Fix XML structure when using numeric keys

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -139,7 +139,7 @@ class ArrayToXml
     protected function addNumericNode(DOMElement $element, $value)
     {
         foreach ($value as $key => $item) {
-            $this->convertElement($element, [$this->numericTagNamePrefix.$key => $value]);
+            $this->convertElement($element, [$this->numericTagNamePrefix.$key => $item]);
         }
     }
 

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_handle_numeric_keys__1.php
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_handle_numeric_keys__1.php
@@ -1,3 +1,5 @@
-<?php return '<?xml version="1.0"?>
+<?php
+
+return '<?xml version="1.0"?>
 <root><numeric_16><parent>aaa</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></numeric_16><numeric_17><parent>bb</parent><numLinks>3</numLinks><child><parent>abb</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></child><child><parent>acb</parent><numLinks>3</numLinks></child></numeric_17></root>
 ';

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_handle_numeric_keys__1.php
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_handle_numeric_keys__1.php
@@ -1,5 +1,3 @@
-<?php
-
-return '<?xml version="1.0"?>
-<root><numeric_16><parent>aaa</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></numeric_16><numeric_16><parent>bb</parent><numLinks>3</numLinks><child><parent>abb</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></child><child><parent>acb</parent><numLinks>3</numLinks></child></numeric_16><numeric_17><parent>aaa</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></numeric_17><numeric_17><parent>bb</parent><numLinks>3</numLinks><child><parent>abb</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></child><child><parent>acb</parent><numLinks>3</numLinks></child></numeric_17></root>
+<?php return '<?xml version="1.0"?>
+<root><numeric_16><parent>aaa</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></numeric_16><numeric_17><parent>bb</parent><numLinks>3</numLinks><child><parent>abb</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></child><child><parent>acb</parent><numLinks>3</numLinks></child></numeric_17></root>
 ';


### PR DESCRIPTION
As mentioned in issue #114, there currently is an issue with the XML output when using numeric keys, which end up being duplicated, thus not respecting the initial structure.

To reproduce the issue, you can use the example in the aforementioned issue, or the following snippet: 

```
<?php

include_once('./src/ArrayToXml.php');

$data = array(
    array(
        'id' => 1,
        'entry' => 'aze',
    ),
    array(
        'id' => 2,
        'entry' => 'rty',
    ),
);

$xml = \Spatie\ArrayToXml\ArrayToXml::convert(['__numeric' => $data]);

var_dump($xml);
```

Currently, this snippet will give you the following output:

```
<?xml version="1.0"?>
<root>
    <numeric_0>
        <id>1</id>
        <entry>aze</entry>
    </numeric_0>
    <numeric_0>
        <id>2</id>
        <entry>rty</entry>
    </numeric_0>
    <numeric_1>
        <id>1</id>
        <entry>aze</entry>
    </numeric_1>
    <numeric_1>
        <id>2</id>
        <entry>rty</entry>
    </numeric_1>
</root>
```

With this PR, here is the output:

```
<?xml version="1.0"?>
<root>
    <numeric_0>
        <id>1</id>
        <entry>aze</entry>
    </numeric_0>
    <numeric_1>
        <id>2</id>
        <entry>rty</entry>
    </numeric_1>
</root>
```