### PR TITLE
Add support for DOCTYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,32 @@ $arrayToXml = new ArrayToXml($array);
 $arrayToXml->setDomProperties(['formatOutput' => true]);
 $result = $arrayToXml->toXml();
 ```
+### Setting a DOCTYPE
+
+To set a document type declaration, you may pass an array containing the [name](https://www.php.net/manual/en/class.domdocumenttype.php#domdocumenttype.props.name)
+ and the [systemId](https://www.php.net/manual/en/class.domdocumenttype.php#domdocumenttype.props.systemid) of the DocumentType.
+
+You can use the constructor to set the Document Type.
+
+```php
+$result = ArrayToXml::convert(
+   $array, 
+   $rootElement, 
+   $replaceSpacesByUnderScoresInKeyNames, 
+   $xmlEncoding, 
+   $xmlVersion,
+   $domProperties,
+   ['animal', 'dog.dtd']
+);
+```
+
+Alternatively you can use  `setDocType`
+
+```php
+$arrayToXml = new ArrayToXml($array);
+$arrayToXml->setDocType(['animal', 'dog.dtd']);
+$result = $arrayToXml->toXml();
+```
 
 ## Testing
 

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -416,4 +416,29 @@ class ArrayToXmlTest extends TestCase
         $this->assertTrue($dom->formatOutput);
         $this->assertEquals('1234567', $dom->version);
     }
+
+    /** @test */
+    public function it_can_accept_a_doctype()
+    {
+        $xml = ArrayToXml::convert(
+            $this->testArray,
+            'root',
+            true,
+            'UTF-8',
+            '1.0',
+            [],
+            ['animal', 'dog.dtd']
+        );
+
+        $this->assertMatchesXmlSnapshot($xml);
+    }
+
+    /** @test */
+    public function it_can_set_a_doctype()
+    {
+        $xml2Array = new ArrayToXml($this->testArray);
+        $xml2Array->setDocType(['greeting', 'hello.dtd']);
+
+        $this->assertMatchesXmlSnapshot($xml2Array->toXml());
+    }
 }

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_accept_a_doctype__1.xml
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_accept_a_doctype__1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE animal SYSTEM "dog.dtd">
+<root>
+  <Good_guy>
+    <name>Luke Skywalker</name>
+    <weapon>Lightsaber</weapon>
+  </Good_guy>
+  <Bad_guy>
+    <name>Sauron</name>
+    <weapon>Evil Eye</weapon>
+  </Bad_guy>
+</root>

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_set_a_doctype__1.xml
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_set_a_doctype__1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE greeting SYSTEM "hello.dtd">
+<root>
+  <Good_guy>
+    <name>Luke Skywalker</name>
+    <weapon>Lightsaber</weapon>
+  </Good_guy>
+  <Bad_guy>
+    <name>Sauron</name>
+    <weapon>Evil Eye</weapon>
+  </Bad_guy>
+</root>


### PR DESCRIPTION
When sending XML documents to strict applications, a [document type declaration](https://www.w3.org/TR/xml/#sec-prolog-dtd) (DOCTYPE) may be necessary.

This PR adds support for setting a DOCTYPE through the constructor or through a `setDocType` method.

For example:
```php
$arrayToXml = new ArrayToXml($array);
$arrayToXml->setDocType(['greeting', 'hello.dtd']);
$result = $arrayToXml->toXml();
```
Results in:

```
<?xml version="1.0"?>
<!DOCTYPE greeting SYSTEM "hello.dtd">
<root>
...
```