### PR TITLE
Add support for custom keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,58 @@ This will result in:
 
 You can change key prefix with setter method called `setNumericTagNamePrefix()`.
 
+### Using custom keys
+
+The package can also can handle custom keys:
+
+```php
+$array = [
+    '__custom:custom-key:1' => [
+        'name' => 'Vladimir',
+        'nickname' => 'greeflas',
+    ],
+    '__custom:custom-key:2' => [
+        'name' => 'Marina',
+        'nickname' => 'estacet',
+        'tags' => [
+            '__custom:tag:1' => 'first-tag',
+            '__custom:tag:2' => 'second-tag',
+        ]
+    ],
+];
+
+$result = ArrayToXml::convert($array);
+```
+
+This will result in:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <custom-key>
+        <name>Vladimir</name>
+        <nickname>greeflas</nickname>
+    </custom-key>
+    <custom-key>
+        <name>Marina</name>
+        <nickname>estacet</nickname>
+        <tags>
+            <tag>first-tag</tag>
+            <tag>second-tag</tag>
+        </tags>
+    </custom-key>
+</root>
+```
+
+A custom key contains three, colon-separated parts: "__custom:[custom-tag]:[unique-string]".
+
+- "__custom"
+  - The key always starts with "__custom".
+- [custom-tag]
+  - The string to be rendered as the XML tag.
+- [unique-string]
+  - A unique string that avoids overwriting of duplicate keys in PHP arrays.
+
 ### Setting DOMDocument properties
 
 To set properties of the internal DOMDocument object just pass an array consisting of keys and values. For a full list of valid properties consult https://www.php.net/manual/en/class.domdocument.php.

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -133,6 +133,8 @@ class ArrayToXml
                     $element->appendChild($fragment);
                 } elseif ($key === '__numeric') {
                     $this->addNumericNode($element, $data);
+                } elseif (substr( $key, 0, 9 ) === "__custom:") {
+                    $this->addNode($element, explode(':', $key)[1], $data);
                 } else {
                     $this->addNode($element, $key, $data);
                 }

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -395,6 +395,43 @@ class ArrayToXmlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_handle_custom_keys()
+    {
+        $this->assertMatchesSnapshot(ArrayToXml::convert([
+            '__custom:custom-key:01' => [
+                'parent' => 'aaa',
+                'numLinks' => 3,
+                'child' => [
+                    16 => [
+                        'parent' => 'abc',
+                        'numLinks' => 3,
+                    ],
+                ],
+            ],
+            '__custom:custom-key:02' => [
+                'parent' => 'bb',
+                'numLinks' => 3,
+                'child' => [
+                    '__custom:custom-subkey:01' => [
+                        'parent' => 'abb',
+                        'numLinks' => 3,
+                        'child' => [
+                            '__custom:custom-subsubkey:01' => [
+                                'parent' => 'abc',
+                                'numLinks' => 3,
+                            ],
+                        ],
+                    ],
+                    '__custom:custom-subkey:02' => [
+                        'parent' => 'acb',
+                        'numLinks' => 3,
+                    ],
+                ],
+            ],
+        ]));
+    } 
+
+    /** @test */
     public function setting_invalid_properties_will_result_in_an_exception()
     {
         $this->expectException(\Exception::class);

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_handle_custom_keys__1.php
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_handle_custom_keys__1.php
@@ -1,0 +1,3 @@
+<?php return '<?xml version="1.0"?>
+<root><custom-key><parent>aaa</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></custom-key><custom-key><parent>bb</parent><numLinks>3</numLinks><child><custom-subkey><parent>abb</parent><numLinks>3</numLinks><child><custom-subsubkey><parent>abc</parent><numLinks>3</numLinks></custom-subsubkey></child></custom-subkey><custom-subkey><parent>acb</parent><numLinks>3</numLinks></custom-subkey></child></custom-key></root>
+';


### PR DESCRIPTION
This PR seeks to add support for custom keys. It solves a problem where duplicative keys in PHP arrays result in overwriting.

Let's say the following XML is desired:

```xml
<root>
  <articles>
    <article>
      <title>Article Title</title>
      <author>Article Author</author>
    </article>
    <article>
      <title>Another Article</title>
      <author>Another Article Author</author>
    </article>
  </articles>
</root>
```

In the example below, only the second (and final) article will be rendered in XML:

```php
$array = [
  ['articles'] =>
    ['article] => [
      ['title] => 'Article Title',
      ['author'] => 'Article Author',
    ],
    ['article] => [
      ['title] => 'Another Article',
      ['author'] => 'Another Article Author',
    ],
  ],
];
```

With this PR, the following array will result in the desired XML:

```php
$array = [
  ['articles'] =>
    ['__custom:article:1] => [
      ['title] => 'Article Title',
      ['author'] => 'Article Author',
    ],
    ['__custom:article:2] => [
      ['title] => 'Another Article',
      ['author'] => 'Another Article Author',
    ],
  ],
];
```

PR contains updated unit tests.