### PR TITLE
Add support for dropping XML declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,36 @@ will result in:
 <root><Good_guy><name>Luke Skywalker</name><weapon>Lightsaber</weapon></Good_guy><Bad_guy><name>Sauron</name><weapon>Evil Eye</weapon></Bad_guy></root>
 ```
 
+### Dropping XML declaration
+
+Call `$arrayToXml->dropXmlDeclaration()` method on ArrayToXml object to omit default XML declaration on top of the generated XML.
+
+Example:
+
+```php
+$root = [
+    'rootElementName' => 'soap:Envelope',
+    '_attributes' => [
+        'xmlns:soap' => 'http://www.w3.org/2003/05/soap-envelope/',
+    ],
+];
+$array = [
+    'soap:Header' => [],
+    'soap:Body' => [
+        'soap:key' => 'soap:value',
+    ],
+];
+$arrayToXml = new ArrayToXml($array, $root);
+
+$result = $arrayToXml->dropXmlDeclaration()->toXml();
+```
+
+This will result in:
+
+```xml
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"><soap:Header/><soap:Body><soap:key>soap:value</soap:key></soap:Body></soap:Envelope>
+```
+
 ## Testing
 
 ```bash

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -13,7 +13,7 @@ class ArrayToXml
 
     protected $replaceSpacesByUnderScoresInKeyNames = true;
 
-    protected $dropXmlDeclaration = false;
+    protected $addXmlDeclaration = true;
 
     protected $numericTagNamePrefix = 'numeric_';
 
@@ -71,7 +71,7 @@ class ArrayToXml
 
     public function toXml(): string
     {
-        if ($this->dropXmlDeclaration) {
+        if ($this->addXmlDeclaration === false) {
             return $this->document->saveXml($this->document->documentElement);
         }
 
@@ -113,7 +113,7 @@ class ArrayToXml
 
     public function dropXmlDeclaration()
     {
-        $this->dropXmlDeclaration = true;
+        $this->addXmlDeclaration = false;
 
         return $this;
     }

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -13,6 +13,8 @@ class ArrayToXml
 
     protected $replaceSpacesByUnderScoresInKeyNames = true;
 
+    protected $dropXmlDeclaration = false;
+
     protected $numericTagNamePrefix = 'numeric_';
 
     public function __construct(
@@ -69,6 +71,10 @@ class ArrayToXml
 
     public function toXml(): string
     {
+        if ($this->dropXmlDeclaration) {
+            return $this->document->saveXml($this->document->documentElement);
+        }
+
         return $this->document->saveXML();
     }
 
@@ -101,6 +107,13 @@ class ArrayToXml
     {
         $this->document->preserveWhiteSpace = false;
         $this->document->formatOutput = true;
+
+        return $this;
+    }
+
+    public function dropXmlDeclaration()
+    {
+        $this->dropXmlDeclaration = true;
 
         return $this;
     }

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -461,14 +461,14 @@ class ArrayToXmlTest extends TestCase
             'soap:Header' => [],
             'soap:Body' => [
                 'soap:key' => 'soap:value',
-            ]
+            ],
         ];
 
         $arrayToXml = new ArrayToXml($body, [
             'rootElement' => 'soap:Envelope',
             '_attributes' => [
                 'xmlns:soap' => 'http://www.w3.org/2003/05/soap-envelope/',
-            ]
+            ],
         ]);
 
         $this->assertMatchesSnapshot($arrayToXml->dropXmlDeclaration()->toXml());

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -457,19 +457,19 @@ class ArrayToXmlTest extends TestCase
     /** @test */
     public function it_can_drop_xml_declaration()
     {
-        $body = [
+        $root = [
+            'rootElementName' => 'soap:Envelope',
+            '_attributes' => [
+                'xmlns:soap' => 'http://www.w3.org/2003/05/soap-envelope/',
+            ],
+        ];
+        $array = [
             'soap:Header' => [],
             'soap:Body' => [
                 'soap:key' => 'soap:value',
             ],
         ];
-
-        $arrayToXml = new ArrayToXml($body, [
-            'rootElement' => 'soap:Envelope',
-            '_attributes' => [
-                'xmlns:soap' => 'http://www.w3.org/2003/05/soap-envelope/',
-            ],
-        ]);
+        $arrayToXml = new ArrayToXml($array, $root);
 
         $this->assertMatchesSnapshot($arrayToXml->dropXmlDeclaration()->toXml());
     }

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -453,4 +453,24 @@ class ArrayToXmlTest extends TestCase
         $this->assertTrue($dom->formatOutput);
         $this->assertEquals('1234567', $dom->version);
     }
+
+    /** @test */
+    public function it_can_drop_xml_declaration()
+    {
+        $body = [
+            'soap:Header' => [],
+            'soap:Body' => [
+                'soap:key' => 'soap:value',
+            ]
+        ];
+
+        $arrayToXml = new ArrayToXml($body, [
+            'rootElement' => 'soap:Envelope',
+            '_attributes' => [
+                'xmlns:soap' => 'http://www.w3.org/2003/05/soap-envelope/',
+            ]
+        ]);
+
+        $this->assertMatchesSnapshot($arrayToXml->dropXmlDeclaration()->toXml());
+    }
 }

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_drop_xml_declaration__1.php
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_drop_xml_declaration__1.php
@@ -1,1 +1,3 @@
-<?php return '<root xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"><soap:Header/><soap:Body><soap:key>soap:value</soap:key></soap:Body></root>';
+<?php
+
+return '<root xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"><soap:Header/><soap:Body><soap:key>soap:value</soap:key></soap:Body></root>';

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_drop_xml_declaration__1.php
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_drop_xml_declaration__1.php
@@ -1,3 +1,3 @@
 <?php
 
-return '<root xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"><soap:Header/><soap:Body><soap:key>soap:value</soap:key></soap:Body></root>';
+return '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"><soap:Header/><soap:Body><soap:key>soap:value</soap:key></soap:Body></soap:Envelope>';

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_drop_xml_declaration__1.php
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_drop_xml_declaration__1.php
@@ -1,0 +1,1 @@
+<?php return '<root xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"><soap:Header/><soap:Body><soap:key>soap:value</soap:key></soap:Body></root>';


### PR DESCRIPTION
Fixes #144 

Simple setter which allows dropping XML declaration. Useful for generating SOAP envelope.

Base snapshot driver must be used to see effects of this change.