### PR TITLE
Add escapable colons in custom keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,44 @@ A custom key contains three, colon-separated parts: "__custom:[custom-tag]:[uniq
 - [unique-string]
   - A unique string that avoids overwriting of duplicate keys in PHP arrays.
 
+a colon character can be included within the custom-tag portion by escaping it with a backslash:
+
+```php
+$array = [
+    '__custom:ns\\:custom-key:1' => [
+        'name' => 'Vladimir',
+        'nickname' => 'greeflas',
+    ],
+    '__custom:ns\\:custom-key:2' => [
+        'name' => 'Marina',
+        'nickname' => 'estacet',
+        'tags' => [
+            '__custom:ns\\:tag:1' => 'first-tag',
+            '__custom:ns\\:tag:2' => 'second-tag',
+        ]
+    ],
+];
+```
+This will result in:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <ns:custom-key>
+        <name>Vladimir</name>
+        <nickname>greeflas</nickname>
+    </ns:custom-key>
+    <ns:custom-key>
+        <name>Marina</name>
+        <nickname>estacet</nickname>
+        <tags>
+            <ns:tag>first-tag</ns:tag>
+            <tns:ag>second-tag</tns:ag>
+        </tags>
+    </ns:custom-key>
+</root>
+```
+
 ### Setting DOMDocument properties
 
 To set properties of the internal DOMDocument object just pass an array consisting of keys and values. For a full list of valid properties consult https://www.php.net/manual/en/class.domdocument.php.

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -154,7 +154,7 @@ class ArrayToXml
                 } elseif ($key === '__numeric') {
                     $this->addNumericNode($element, $data);
                 } elseif (substr($key, 0, 9) === '__custom:') {
-                    $this->addNode($element, explode(':', $key)[1], $data);
+                    $this->addNode($element, str_replace('\:', ':', preg_split('/(?<!\\\):/', $key)[1]), $data);
                 } else {
                     $this->addNode($element, $key, $data);
                 }

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -438,6 +438,43 @@ class ArrayToXmlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_handle_custom_keys_containing_colon_character()
+    {
+        $this->assertMatchesSnapshot(ArrayToXml::convert([
+            '__custom:custom\:key:01' => [
+                'parent' => 'aaa',
+                'numLinks' => 3,
+                'child' => [
+                    16 => [
+                        'parent' => 'abc',
+                        'numLinks' => 3,
+                    ],
+                ],
+            ],
+            '__custom:custom\:key:02' => [
+                'parent' => 'bb',
+                'numLinks' => 3,
+                'child' => [
+                    '__custom:custom\:subkey:01' => [
+                        'parent' => 'abb',
+                        'numLinks' => 3,
+                        'child' => [
+                            '__custom:custom\:subsubkey:01' => [
+                                'parent' => 'abc',
+                                'numLinks' => 3,
+                            ],
+                        ],
+                    ],
+                    '__custom:custom\:subkey:02' => [
+                        'parent' => 'acb',
+                        'numLinks' => 3,
+                    ],
+                ],
+            ],
+        ]));
+    }
+
+    /** @test */
     public function setting_invalid_properties_will_result_in_an_exception()
     {
         $this->expectException(\Exception::class);

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_handle_custom_keys_containing_colon_character__1.php
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_handle_custom_keys_containing_colon_character__1.php
@@ -1,0 +1,5 @@
+<?php
+
+return '<?xml version="1.0"?>
+<root><custom:key><parent>aaa</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></custom:key><custom:key><parent>bb</parent><numLinks>3</numLinks><child><custom:subkey><parent>abb</parent><numLinks>3</numLinks><child><custom:subsubkey><parent>abc</parent><numLinks>3</numLinks></custom:subsubkey></child></custom:subkey><custom:subkey><parent>acb</parent><numLinks>3</numLinks></custom:subkey></child></custom:key></root>
+';

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_handle_custom_keys_containing_colon_character__1.txt
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_handle_custom_keys_containing_colon_character__1.txt
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<root><custom:key><parent>aaa</parent><numLinks>3</numLinks><child><parent>abc</parent><numLinks>3</numLinks></child></custom:key><custom:key><parent>bb</parent><numLinks>3</numLinks><child><custom:subkey><parent>abb</parent><numLinks>3</numLinks><child><custom:subsubkey><parent>abc</parent><numLinks>3</numLinks></custom:subsubkey></child></custom:subkey><custom:subkey><parent>acb</parent><numLinks>3</numLinks></custom:subkey></child></custom:key></root>


### PR DESCRIPTION
Allows for colon characters as part of the custom key syntax by backslash escaping them. 

 e.g. `__custom:ns\:parameter:1` will resolve to a custom key of `ns:parameter`

I really appreciate how easy this package is making it to build XML for interaction with a partner's SOAP interface Unfortunately, I have encountered a scenario requiring colon-delimited custom keys, which isn't possible (that I know of) using the current explode() approach. This modification would allow more flexibility in the custom key name.

Thank you so much for this and so many other packages, and for considering this PR! 