### PR TITLE
Ability to add processing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,27 @@ This will result in:
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"><soap:Header/><soap:Body><soap:key>soap:value</soap:key></soap:Body></soap:Envelope>
 ```
 
+### Adding Processing Instructions
+
+Call `$arrayToXml->addProcessingInstruction($target, $data)` method on ArrayToXml object to prepend a processing instruction before the root element.
+
+Example:
+
+```php
+
+$arrayToXml = new ArrayToXml($array);
+$arrayToXml->addProcessingInstruction('xml-stylesheet', 'type="text/xsl" href="base.xsl"');
+$result = $arrayToXml->toXml();
+```
+
+This will result in:
+
+```xml
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="base.xsl"?>
+<root><Good_guy><name>Luke Skywalker</name><weapon>Lightsaber</weapon></Good_guy><Bad_guy><name>Sauron</name><weapon>Evil Eye</weapon></Bad_guy></root>
+```
+
 ## Testing
 
 ```bash

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -123,6 +123,17 @@ class ArrayToXml
         return $this;
     }
 
+    public function addProcessingInstruction($target, $data)
+    {
+        $elements = $this->document->getElementsByTagName('*');
+
+        $rootElement = $elements->count() > 0 ? $elements->item(0) : null;
+
+        $this->document->insertBefore($this->document->createProcessingInstruction($target, $data), $rootElement);
+
+        return $this;
+    }
+
     protected function convertElement(DOMElement $element, mixed $value): void
     {
         $sequential = $this->isArrayAllKeySequential($value);

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -515,4 +515,14 @@ class ArrayToXmlTest extends TestCase
 
         $this->assertMatchesSnapshot($arrayToXml->dropXmlDeclaration()->toXml());
     }
+
+    /** @test */
+    public function it_can_add_processing_instructions()
+    {
+        $arrayToXml = new ArrayToXml($this->testArray);
+
+        $arrayToXml->addProcessingInstruction('xml-stylesheet', 'type="text/xsl" href="base.xsl"');
+
+        $this->assertMatchesSnapshot($arrayToXml->toXml());
+    }
 }

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_add_processing_instructions__1.txt
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_add_processing_instructions__1.txt
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="base.xsl"?>
+<root><Good_guy><name>Luke Skywalker</name><weapon>Lightsaber</weapon></Good_guy><Bad_guy><name>Sauron</name><weapon>Evil Eye</weapon></Bad_guy></root>


### PR DESCRIPTION
I came across this issue #143 and also needed this feature. It adds the method `addProcessingInstruction($target, $data)` to the `ArrayToXML` object and can be used like this:

```php
$arrayToXml = new ArrayToXml($array);
$arrayToXml->addProcessingInstruction('qbxml', 'version="13.0"');
$result = $arrayToXml->toXml();
```
Which would generate:
```xml
<?xml version="1.0"?>
<?qbxml version="13.0"?>
<root><Good_guy><name>Luke Skywalker</name><weapon>Lightsaber</weapon></Good_guy><Bad_guy><name>Sauron</name><weapon>Evil Eye</weapon></Bad_guy></root>
```

Multiple processing instructions can be added, and they will always be prepended above the root element.

I figured this may not be used enough to justify adding it to the `convert()` method arguments, but am happy to add it there if wanted.