### PR TITLE
allow null inside array to be converted to xml

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -208,7 +208,7 @@ class ArrayToXml
         $element->parentNode->appendChild($child);
     }
 
-    protected function isArrayAllKeySequential(array | string $value): bool
+    protected function isArrayAllKeySequential(array | string | null $value): bool
     {
         if (! is_array($value)) {
             return false;

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -515,4 +515,14 @@ class ArrayToXmlTest extends TestCase
 
         $this->assertMatchesSnapshot($arrayToXml->dropXmlDeclaration()->toXml());
     }
+
+    /** @test */
+    public function it_can_convert_an_array_with_null_value_to_xml()
+    {
+        $arr = [
+            'test' => null,
+        ];
+
+        $this->assertMatchesXmlSnapshot(ArrayToXml::convert($arr));
+    }
 }

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_convert_an_array_with_null_value_to_xml__1.xml
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_convert_an_array_with_null_value_to_xml__1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<root>
+  <test/>
+</root>


### PR DESCRIPTION
Regarding this issue. https://github.com/spatie/array-to-xml/issues/169

This will allow null to be present in array.

For example, convert this array 

```
$arr = [
    'test' => null,
];

ArrayToXml::convert($arr);
```

to below xml

```
<?xml version="1.0"?>
<root>
  <test/>
</root>
```