### PR TITLE
DOMDocument constructor default values

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -21,7 +21,7 @@ class ArrayToXml
         array $array,
         string | array $rootElement = '',
         bool $replaceSpacesByUnderScoresInKeyNames = true,
-        ?string $xmlEncoding = null,
+        string $xmlEncoding = '',
         string $xmlVersion = '1.0',
         array $domProperties = [],
         ?bool $xmlStandalone = null
@@ -56,9 +56,9 @@ class ArrayToXml
 
     public static function convert(
         array $array,
-        $rootElement = '',
+              $rootElement = '',
         bool $replaceSpacesByUnderScoresInKeyNames = true,
-        string $xmlEncoding = null,
+        string $xmlEncoding = '',
         string $xmlVersion = '1.0',
         array $domProperties = [],
         bool $xmlStandalone = null
@@ -141,9 +141,10 @@ class ArrayToXml
         $sequential = $this->isArrayAllKeySequential($value);
 
         if (! is_array($value)) {
-            $value = htmlspecialchars($value);
-
-            $value = $this->removeControlCharacters($value);
+            if (! is_null($value)) {
+                $value = htmlspecialchars($value);
+                $value = $this->removeControlCharacters($value);
+            }
 
             $element->nodeValue = $value;
 

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -122,13 +122,13 @@ class ArrayToXmlTest extends TestCase
     /** @test */
     public function it_accepts_an_xml_version()
     {
-        $this->assertMatchesSnapshot(ArrayToXml::convert([], '', false, null, '1.1'));
+        $this->assertMatchesSnapshot(ArrayToXml::convert([], '', false, '', '1.1'));
     }
 
     /** @test */
     public function it_accepts_an_xml_standalone_value()
     {
-        $this->assertMatchesSnapshot(ArrayToXml::convert([], '', false, null, '1.0', [], false));
+        $this->assertMatchesSnapshot(ArrayToXml::convert([], '', false, '', '1.0', [], false));
     }
 
     /** @test */
@@ -515,7 +515,7 @@ class ArrayToXmlTest extends TestCase
 
         $this->assertMatchesSnapshot($arrayToXml->dropXmlDeclaration()->toXml());
     }
-    
+
     /** @test */
     public function it_can_convert_an_array_with_null_value_to_xml()
     {
@@ -525,7 +525,7 @@ class ArrayToXmlTest extends TestCase
 
         $this->assertMatchesXmlSnapshot(ArrayToXml::convert($arr));
     }
-  
+
     /** @test */
     public function it_can_add_processing_instructions()
     {


### PR DESCRIPTION
default xmlEncoding value can no longer be null for DOMDocument ctor

Signed-off-by: Julien Guittard <julien.guittard@me.com>