### PR TITLE
PHP 8.1 fix deprecated null parameters

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -21,12 +21,12 @@ class ArrayToXml
         array $array,
         string | array $rootElement = '',
         bool $replaceSpacesByUnderScoresInKeyNames = true,
-        ?string $xmlEncoding = null,
+        ?string $xmlEncoding = null ?? '',
         string $xmlVersion = '1.0',
         array $domProperties = [],
         ?bool $xmlStandalone = null
     ) {
-        $this->document = new DOMDocument($xmlVersion, $xmlEncoding);
+        $this->document = new DOMDocument($xmlVersion, $xmlEncoding ?? '');
 
         if (! is_null($xmlStandalone)) {
             $this->document->xmlStandalone = $xmlStandalone;

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -21,7 +21,7 @@ class ArrayToXml
         array $array,
         string | array $rootElement = '',
         bool $replaceSpacesByUnderScoresInKeyNames = true,
-        ?string $xmlEncoding = null ?? '',
+        ?string $xmlEncoding = null,
         string $xmlVersion = '1.0',
         array $domProperties = [],
         ?bool $xmlStandalone = null

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -141,7 +141,7 @@ class ArrayToXml
         $sequential = $this->isArrayAllKeySequential($value);
 
         if (! is_array($value)) {
-            $value = htmlspecialchars($value);
+            $value = htmlspecialchars($value ?? '');
 
             $value = $this->removeControlCharacters($value);
 


### PR DESCRIPTION
fix #186 ($string) of type string is deprecated in PHP 8.1