### PR TITLE
V3 - Code smell ('incorrect' method call)

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -80,7 +80,7 @@ class ArrayToXml
     {
         return $this->addXmlDeclaration
             ? $this->document->saveXML()
-            : $this->document->saveXml($this->document->documentElement);
+            : $this->document->saveXML($this->document->documentElement);
     }
 
     public function toDom(): DOMDocument


### PR DESCRIPTION
Incorrect method call to `->saveXml()` (Should be `->saveXML()`).

It's not a bug, but merely a code smell issue.