### PR TITLE
Upgrade `dependabot/fetch-metadata`

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.5
+        uses: dependabot/fetch-metadata@v1.3.6
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           compat-lookup: true


### PR DESCRIPTION
- Bump `dependabot/fetch-metadata` from 1.3.5 to 1.3.6

Backports spatie/array-to-xml#210
