### PR TITLE
Use proper NULL value when we wanna use with XSD

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -11,6 +11,7 @@ use Exception;
 class ArrayToXml
 {
     protected DOMDocument $document;
+    protected DOMElement $rootNode;
 
     protected bool $replaceSpacesByUnderScoresInKeyNames = true;
 
@@ -46,11 +47,11 @@ class ArrayToXml
             throw new DOMException('Invalid Character Error');
         }
 
-        $root = $this->createRootElement($rootElement);
+        $this->rootNode = $this->createRootElement($rootElement);
 
-        $this->document->appendChild($root);
+        $this->document->appendChild($this->rootNode);
 
-        $this->convertElement($root, $array);
+        $this->convertElement($this->rootNode, $array);
     }
 
     public function setNumericTagNamePrefix(string $prefix): void
@@ -201,8 +202,22 @@ class ArrayToXml
         }
 
         $child = $this->document->createElement($key);
+
+        $this->addNodeTypeAttribute($child, $value);
+
         $element->appendChild($child);
         $this->convertElement($child, $value);
+    }
+
+    protected function addNodeTypeAttribute(DOMElement $element, mixed $value): void
+    {
+        if (is_null($value)) {
+            if (!$this->rootNode->hasAttribute('xmlns:xsi')) {
+                $this->rootNode->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+            }
+
+            $element->setAttribute('xsi:nil', 'true');
+        }
     }
 
     protected function addCollectionNode(DOMElement $element, mixed $value): void

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -480,9 +480,10 @@ it('can drop xml declaration', function () {
     assertMatchesSnapshot($arrayToXml->dropXmlDeclaration()->toXml());
 });
 
-it('can convert an array with null value to xml', function () {
+it('can convert an array with empty string and null value to xml', function () {
     $arr = [
-        'test' => null,
+        'testString' => '',
+        'testNull' => null,
     ];
 
     assertMatchesXmlSnapshot(ArrayToXml::convert($arr));

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_convert_an_array_with_empty_string_and_null_value_to_xml__1.xml
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_convert_an_array_with_empty_string_and_null_value_to_xml__1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <testString/>
+  <testNull xsi:nil="true"/>
+</root>

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_convert_an_array_with_null_value_to_xml__1.xml
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_convert_an_array_with_null_value_to_xml__1.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<root>
-  <test/>
-</root>


### PR DESCRIPTION
When XML is validated against XSD with `nullable=true` definition then PHP NULL should be converted to proper XML value.

`<element></element> or <element/>` is parsed always as empty string. When field is missing then it is not defined. So when value is null, we should provide proper information to XML parsers.

Reference: https://www.w3.org/TR/xmlschema-0/#Nils

Output validated against: https://jsonformatter.org/xml-viewer/a0b80a
XML output converted to XSD schema: https://www.liquid-technologies.com/online-xml-to-xsd-converter

There is a chance that simpler XML parsers could consider `xsi:nil="true"` still as string