### PR TITLE
Add proper boolean conversion to xml representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `array-to-xml` will be documented in this file
 
+## 3.2.3 - 2023-11-14
+
+### What's Changed
+
+- Convert boolean values to proper xml representation by @radeno in https://github.com/spatie/array-to-xml/pull/XXX
+
 ## 3.2.2 - 2023-11-14
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to `array-to-xml` will be documented in this file
 
-## 3.2.3 - 2023-11-14
+## 3.2.3 - 2024-XX-XX
 
 ### What's Changed
 
-- Convert boolean values to proper xml representation by @radeno in https://github.com/spatie/array-to-xml/pull/XXX
+- Convert boolean values to proper xml representation by @radeno in https://github.com/spatie/array-to-xml/pull/228
 
 ## 3.2.2 - 2023-11-14
 

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -19,7 +19,7 @@ class ArrayToXml
 
     protected string $numericTagNamePrefix = 'numeric_';
 
-    protected array $options = ['convertNullToXsiNil' => false];
+    protected array $options = ['convertNullToXsiNil' => false, 'convertBoolToString' => false];
 
     public function __construct(
         array $array,
@@ -30,7 +30,7 @@ class ArrayToXml
         array $domProperties = [],
         bool | null $xmlStandalone = null,
         bool $addXmlDeclaration = true,
-        array | null $options = ['convertNullToXsiNil' => false]
+        array | null $options = ['convertNullToXsiNil' => false, 'convertBoolToString' => false]
     ) {
         $this->document = new DOMDocument($xmlVersion, $xmlEncoding ?? '');
 
@@ -213,7 +213,19 @@ class ArrayToXml
         $this->addNodeTypeAttribute($child, $value);
 
         $element->appendChild($child);
+
+        $value = $this->convertNodeValue($child, $value);
+
         $this->convertElement($child, $value);
+    }
+
+    protected function convertNodeValue(DOMElement $element, mixed $value): mixed
+    {
+        if ($this->options['convertBoolToString'] && is_bool($value)) {
+            $value = $value ? 'true' : 'false';
+        }
+
+        return $value;
     }
 
     protected function addNodeTypeAttribute(DOMElement $element, mixed $value): void

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -504,7 +504,7 @@ it('can not convert boolean values to xml representation', function () {
         'testTrue' => true,
     ];
 
-    assertMatchesXmlSnapshot(ArrayToXml::convert($arr, '', true, null, '1.0', [], null, true, ['convertBoolToString' => false]));
+    assertMatchesXmlSnapshot(ArrayToXml::convert($arr));
 });
 
 it('can convert an array with empty string and null value to xml', function () {

--- a/tests/ArrayToXmlTest.php
+++ b/tests/ArrayToXmlTest.php
@@ -489,6 +489,24 @@ it('can convert an array with empty string and null value to xml with option', f
     assertMatchesXmlSnapshot(ArrayToXml::convert($arr, '', true, null, '1.0', [], null, true, ['convertNullToXsiNil' => true]));
 });
 
+it('can convert boolean values to xml representation', function () {
+    $arr = [
+        'testFalse' => false,
+        'testTrue' => true,
+    ];
+
+    assertMatchesXmlSnapshot(ArrayToXml::convert($arr, '', true, null, '1.0', [], null, true, ['convertBoolToString' => true]));
+});
+
+it('can not convert boolean values to xml representation', function () {
+    $arr = [
+        'testFalse' => false,
+        'testTrue' => true,
+    ];
+
+    assertMatchesXmlSnapshot(ArrayToXml::convert($arr, '', true, null, '1.0', [], null, true, ['convertBoolToString' => false]));
+});
+
 it('can convert an array with empty string and null value to xml', function () {
     $arr = [
         'testString' => '',

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_convert_boolean_values_to_xml_representation__1.xml
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_convert_boolean_values_to_xml_representation__1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<root>
+  <testFalse>false</testFalse>
+  <testTrue>true</testTrue>
+</root>

--- a/tests/__snapshots__/ArrayToXmlTest__it_can_not_convert_boolean_values_to_xml_representation__1.xml
+++ b/tests/__snapshots__/ArrayToXmlTest__it_can_not_convert_boolean_values_to_xml_representation__1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<root>
+  <testFalse/>
+  <testTrue>1</testTrue>
+</root>


### PR DESCRIPTION
Currently, boolean values are converted incorrectly. Only `true` value is converted to 1 which is allowed value. `false` is converted as an empty attribute, which is incorrect.

Based on https://www.w3.org/TR/xmlschema-2/#boolean

`true, false, 1, 0` are allowed values.

We don't want to break previous behavior so that feature can be enabled by option.