### PR TITLE
Fix explicit nullable parameter for PHP 8.4 compatibility

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -40,5 +40,6 @@ return $config->setFinder($finder)
             'keep_multiple_spaces_after_comma' => true,
         ],
         'single_trait_insert_per_statement' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setRiskyAllowed(true);

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
     "scripts": {
         "test": "vendor/bin/pest"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "3.x-dev"
+        }
+    },
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -68,10 +68,10 @@ class ArrayToXml
         array $array,
         $rootElement = '',
         bool $replaceSpacesByUnderScoresInKeyNames = true,
-        string $xmlEncoding = null,
+        ?string $xmlEncoding = null,
         string $xmlVersion = '1.0',
         array $domProperties = [],
-        bool $xmlStandalone = null,
+        ?bool $xmlStandalone = null,
         bool $addXmlDeclaration = true,
         array $options = ['convertNullToXsiNil' => false]
     ): string {


### PR DESCRIPTION
Using php-cs-fixer's rule [`nullable_type_declaration_for_default_null_value`](https://cs.symfony.com/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.html#rule-nullable-type-declaration-for-default-null-value).

Also add the branch alias for 3.x