### PR TITLE
Allow passing of saveXML options

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -93,7 +93,7 @@ class ArrayToXml
     public function toXml($options = 0): string
     {
         return $this->addXmlDeclaration
-            ? $this->document->saveXML(null, $options)
+            ? $this->document->saveXML(options: $options)
             : $this->document->saveXML($this->document->documentElement, $options);
     }
 

--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -90,11 +90,11 @@ class ArrayToXml
         return $converter->toXml();
     }
 
-    public function toXml(): string
+    public function toXml($options = 0): string
     {
         return $this->addXmlDeclaration
-            ? $this->document->saveXML()
-            : $this->document->saveXML($this->document->documentElement);
+            ? $this->document->saveXML(null, $options)
+            : $this->document->saveXML($this->document->documentElement, $options);
     }
 
     public function toDom(): DOMDocument


### PR DESCRIPTION
This PR introduces the ability to pass options to the [DOMDocument's saveXML method](https://www.php.net/manual/en/domdocument.savexml.php).

This allows the use of [LIBXML_NOEMPTYTAG](https://www.php.net/manual/en/libxml.constants.php) and [LIBXML_NOXMLDECL](https://www.php.net/manual/en/libxml.constants.php). 